### PR TITLE
Bug with overflowing _counter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scriptinator/winston-influx",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/src/InfluxWriter.js
+++ b/src/InfluxWriter.js
@@ -49,7 +49,7 @@ module.exports = class InfluxWriter {
      * @param {Date} [time=new Date()] The time for the measurement.
      */
     writePoint(measurement, tags, fields, time = new Date()) {
-        this._counter = this._counter + 1 % 1000;
+        this._counter = (this._counter + 1) % 1000;
 
         this._batcher.write({
             measurement: measurement,

--- a/test/InfluxWriter.js
+++ b/test/InfluxWriter.js
@@ -32,4 +32,11 @@ describe('InfluxWriter', function () {
 
         writer.writePoint('test', {a: 'b'}, {time: 5});
     });
+
+    it('write 1001 requests to influx - we should properly rotate counter', function () {
+        const writer = new InfluxWriter();
+        writer._counter = 1000;
+        writer.writePoint("test", {a: 'b'}, {time: 5});
+        expect(writer._counter).to.equal(1);
+    });
 });


### PR DESCRIPTION
When counter reach more then 1000 points, its does not do modulo, but overflows.
This leads to storing bigger integer then expected.
Error 400 will be thrown from influx: `strconv.ParseInt: parsing \"15614548743320004847\": value out of range`

I've included test and new version into this bugfix.